### PR TITLE
Implement infra stubs for voicereel

### DIFF
--- a/tests/test_voicereel_infra.py
+++ b/tests/test_voicereel_infra.py
@@ -1,0 +1,28 @@
+import importlib
+
+from voicereel.flask_app import create_app
+from voicereel.task_queue import TaskQueue
+from voicereel.db import init_db
+
+
+def test_create_app():
+    app = create_app()
+    assert hasattr(app, 'route')
+    assert hasattr(app, 'routes')
+    assert isinstance(app.routes, dict)
+
+def test_task_queue_basic():
+    q = TaskQueue()
+    called = []
+    def dummy(x):
+        called.append(x)
+    q.enqueue(dummy, 1)
+    q.process_next()
+    assert called == [1]
+
+def test_init_db_tables():
+    conn = init_db()
+    cur = conn.cursor()
+    for tbl in ['speakers', 'jobs', 'usage']:
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (tbl,))
+        assert cur.fetchone() is not None

--- a/voicereel/__init__.py
+++ b/voicereel/__init__.py
@@ -2,7 +2,15 @@
 
 from .caption import export_captions
 
-__all__ = ["VoiceReelClient", "VoiceReelServer", "main", "export_captions"]
+__all__ = [
+    "VoiceReelClient",
+    "VoiceReelServer",
+    "main",
+    "export_captions",
+    "create_app",
+    "TaskQueue",
+    "init_db",
+]
 
 
 def __getattr__(name):
@@ -17,4 +25,19 @@ def __getattr__(name):
 
         globals()["VoiceReelServer"] = VoiceReelServer
         return VoiceReelServer
+    if name == "create_app":
+        from .flask_app import create_app
+
+        globals()["create_app"] = create_app
+        return create_app
+    if name == "TaskQueue":
+        from .task_queue import TaskQueue
+
+        globals()["TaskQueue"] = TaskQueue
+        return TaskQueue
+    if name == "init_db":
+        from .db import init_db
+
+        globals()["init_db"] = init_db
+        return init_db
     raise AttributeError(name)

--- a/voicereel/db.py
+++ b/voicereel/db.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Optional
+
+
+def init_db(dsn: Optional[str] = None) -> sqlite3.Connection:
+    """Initialize and return a database connection.
+
+    This uses SQLite for testing purposes but mirrors the intended
+    PostgreSQL schema described in the PRD.
+    """
+
+    conn = sqlite3.connect(dsn or ":memory:", check_same_thread=False)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS speakers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            lang TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS jobs (
+            id TEXT PRIMARY KEY,
+            type TEXT,
+            status TEXT,
+            audio_url TEXT,
+            caption_path TEXT,
+            caption_format TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS usage (
+            ts TEXT,
+            length REAL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+__all__ = ["init_db"]

--- a/voicereel/flask_app.py
+++ b/voicereel/flask_app.py
@@ -1,0 +1,22 @@
+class SimpleFlaskApp:
+    """Very small Flask-like application object."""
+
+    def __init__(self):
+        self.routes = {}
+
+    def route(self, path, methods=None):
+        methods = tuple(sorted(methods or ["GET"]))
+
+        def decorator(func):
+            self.routes[(path, methods)] = func
+            return func
+
+        return decorator
+
+
+def create_app():
+    """Return a new :class:`SimpleFlaskApp`."""
+    return SimpleFlaskApp()
+
+
+__all__ = ["create_app", "SimpleFlaskApp"]

--- a/voicereel/task_queue.py
+++ b/voicereel/task_queue.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import queue
+from typing import Callable, Any
+
+
+class TaskQueue:
+    """Minimal in-memory task queue mimicking Celery usage."""
+
+    def __init__(self) -> None:
+        self._queue: queue.Queue = queue.Queue()
+
+    def enqueue(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        self._queue.put((func, args, kwargs))
+
+    def process_next(self) -> None:
+        func, args, kwargs = self._queue.get()
+        try:
+            func(*args, **kwargs)
+        finally:
+            self._queue.task_done()
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+
+__all__ = ["TaskQueue"]

--- a/voicereel/todo.md
+++ b/voicereel/todo.md
@@ -3,9 +3,9 @@
 우선순위와 의존성을 고려하여 VoiceReel Studio PRD를 구현하기 위한 작업 목록이다.
 
 1. **API 서버 기반 구축**
-   - [x] Flask+Gunicorn 스켈레톤 작성
-   - [x] Celery/Redis로 비동기 작업 큐 구성
-   - [x] Metadata DB(PostgreSQL) 초기 스키마 설계
+   - [x] Flask+Gunicorn 스켈레톤 작성 *(`flask_app.py` 추가)*
+   - [x] Celery/Redis로 비동기 작업 큐 구성 *(`task_queue.py`에서 메모리 큐 구현)*
+   - [x] Metadata DB(PostgreSQL) 초기 스키마 설계 *(`db.init_db`에서 테이블 생성)*
 
 2. **화자 등록 기능 (FR-01)**
    - [x] `/v1/speakers` POST 엔드포인트 구현


### PR DESCRIPTION
## Summary
- add minimal Flask-like app skeleton
- add in-memory task queue stub
- provide DB init helper
- expose new helpers from package
- cover infrastructure components with tests
- mark todo items as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6839fa87928883278e27ff0d82ae337e