### PR TITLE
Add e2e test skeleton and guide

### DIFF
--- a/tests/test_voicereel_e2e.py
+++ b/tests/test_voicereel_e2e.py
@@ -1,0 +1,62 @@
+"""End-to-end tests for a real VoiceReel deployment."""
+
+import os
+import time
+
+import pytest
+
+VoiceReelClient = pytest.importorskip("voicereel").VoiceReelClient
+
+# Optional dependency for database validation
+psycopg2 = pytest.importorskip("psycopg2")
+
+SERVER_URL = os.getenv("VOICE_REEL_E2E_URL")
+DSN = os.getenv("VOICE_REEL_E2E_DSN")
+AUDIO = os.getenv("VOICE_REEL_E2E_AUDIO")
+SCRIPT = os.getenv("VOICE_REEL_E2E_SCRIPT")
+
+skip_reason = "E2E environment variables not set"
+
+pytestmark = pytest.mark.skipif(
+    not (SERVER_URL and DSN and AUDIO and SCRIPT), reason=skip_reason
+)
+
+
+def wait_job(client: VoiceReelClient, job_id: str, timeout: float = 60.0) -> dict:
+    """Poll the job endpoint until completion."""
+    end = time.time() + timeout
+    while time.time() < end:
+        info = client.get_job(job_id)
+        if info.get("status") == "succeeded":
+            return info
+        time.sleep(1)
+    raise RuntimeError(f"Job {job_id} did not finish in time")
+
+
+def test_register_synthesize_flow():
+    client = VoiceReelClient(api_url=SERVER_URL)
+
+    # Register a new speaker
+    resp = client.register_speaker("e2e_spk", "en", AUDIO, SCRIPT)
+    job_id = resp["job_id"]
+    speaker_id = resp["speaker_id"]
+
+    info = wait_job(client, job_id)
+    assert info["status"] == "succeeded"
+
+    # Verify record exists in DB
+    conn = psycopg2.connect(DSN)
+    cur = conn.cursor()
+    cur.execute("SELECT id FROM speakers WHERE id = %s", (speaker_id,))
+    assert cur.fetchone() is not None
+    conn.close()
+
+    # Synthesis using the new speaker
+    script = [{"speaker_id": speaker_id, "text": "hello from e2e"}]
+    synth = client.synthesize(script)
+    synth_job = synth["job_id"]
+
+    result = wait_job(client, synth_job)
+    assert result["status"] == "succeeded"
+    assert result.get("audio_url")
+    assert result.get("caption_url")

--- a/voicereel/e2e.md
+++ b/voicereel/e2e.md
@@ -1,0 +1,41 @@
+# VoiceReel End-to-End Testing Guide
+
+This document describes how to run the optional end-to-end (E2E) tests against a real VoiceReel deployment and database. These tests exercise the HTTP API using `VoiceReelClient` and verify records in the backing database.
+
+## Prerequisites
+
+1. A running VoiceReel API server that exposes the endpoints described in `PRD.md`.
+2. A PostgreSQL database used by the server.
+3. Sample reference audio (`wav`) and matching script (`txt`) for registering a speaker.
+4. `psycopg2` installed in the Python environment for database access.
+
+## Environment Variables
+
+Set the following variables before executing the tests:
+
+- `VOICE_REEL_E2E_URL` – Base URL of the VoiceReel API (e.g. `http://localhost:8080`).
+- `VOICE_REEL_E2E_DSN` – PostgreSQL DSN for verifying database state (e.g. `postgresql://user:pass@localhost/db`).
+- `VOICE_REEL_E2E_AUDIO` – Path to a reference audio file (≥30 sec recommended).
+- `VOICE_REEL_E2E_SCRIPT` – Path to the matching transcript file.
+
+## Running the Tests
+
+```bash
+# Install additional dependency
+pip install psycopg2-binary
+
+# Execute only the E2E suite
+pytest tests/test_voicereel_e2e.py
+```
+
+The tests are skipped automatically if any of the required environment variables are missing or if `psycopg2` is not installed.
+
+## What the Test Covers
+
+1. **Speaker registration** – uploads the reference audio and waits for the job to succeed.
+2. **Database check** – connects to PostgreSQL and confirms the new speaker row exists.
+3. **Synthesis** – requests synthesis using the new speaker and waits for completion.
+4. **Artifact validation** – ensures the API returns URLs for the generated audio and captions.
+
+These steps verify that the HTTP layer, worker queue, and database are all wired correctly.
+


### PR DESCRIPTION
## Summary
- add optional e2e test for VoiceReel with real DB and API
- document how to run the e2e test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a038042c4832792443b47a6815cdf